### PR TITLE
Allow collecting from iterators

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -1,5 +1,6 @@
 use std::borrow::Borrow;
 use std::cmp::Ordering;
+use std::iter::FromIterator;
 
 use crate::{SkipList, AbstractOrd, QWrapper};
 
@@ -48,5 +49,27 @@ where
 {
     fn cmp(&self, rhs: &KeyValue<K, V>) -> Ordering {
         Ord::cmp(&self.0, rhs.0.borrow())
+    }
+}
+
+impl<K: Ord, V> Extend<(K, V)> for Map<K, V> {
+    fn extend<I: IntoIterator<Item = (K, V)>>(&mut self, iter: I) {
+        let iter = iter.into_iter().map(|(key, value)| KeyValue(key, value));
+        self.inner.extend(iter);
+    }
+}
+
+impl<'a, K: Ord + Copy, V: Copy> Extend<(&'a K, &'a V)> for Map<K, V> {
+    fn extend<I: IntoIterator<Item = (&'a K, &'a V)>>(&mut self, iter: I) {
+        let iter = iter.into_iter().map(|(&key, &value)| KeyValue(key, value));
+        self.inner.extend(iter);
+    }
+}
+
+impl<K: Ord, V> FromIterator<(K, V)> for Map<K, V> {
+    fn from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Self {
+        let mut map = Self::new();
+        map.extend(iter);
+        map
     }
 }

--- a/src/set.rs
+++ b/src/set.rs
@@ -1,4 +1,5 @@
 use std::borrow::Borrow;
+use std::iter::FromIterator;
 
 use crate::{SkipList, QWrapper};
 use crate::skiplist::*;
@@ -73,4 +74,31 @@ impl<'a, T: 'a> Iterator for Iter<'a, T> {
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next()
     }
+}
+
+impl<T: Ord> Extend<T> for Set<T> {
+    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+        self.inner.extend(iter);
+    }
+}
+
+impl<'a, T: 'a + Ord + Copy> Extend<&'a T> for Set<T> {
+    fn extend<I: IntoIterator<Item = &'a T>>(&mut self, iter: I) {
+        self.inner.extend(iter.into_iter().copied());
+    }
+}
+
+impl<T: Ord> FromIterator<T> for Set<T> {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        let mut set = Self::new();
+        set.extend(iter);
+        set
+    }
+}
+
+#[test]
+fn test_collect() {
+    let range = 0..100;
+    let set: Set<_> = range.clone().collect();
+    range.for_each(|i| assert!(set.contains(&i)));
 }

--- a/src/set.rs
+++ b/src/set.rs
@@ -84,7 +84,7 @@ impl<T: Ord> Extend<T> for Set<T> {
 
 impl<'a, T: 'a + Ord + Copy> Extend<&'a T> for Set<T> {
     fn extend<I: IntoIterator<Item = &'a T>>(&mut self, iter: I) {
-        self.inner.extend(iter.into_iter().copied());
+        self.inner.extend(iter);
     }
 }
 

--- a/src/skiplist/mod.rs
+++ b/src/skiplist/mod.rs
@@ -5,6 +5,7 @@ mod iter;
 use std::alloc;
 use std::cmp;
 use std::fmt;
+use std::iter::FromIterator;
 use std::mem;
 use std::ptr::{self, NonNull};
 use std::sync::atomic::{AtomicPtr, AtomicU8};
@@ -169,6 +170,22 @@ impl<T: AbstractOrd<T>> Extend<T> for SkipList<T> {
         iter.into_iter().for_each(|elem| {
             self.insert(elem);
         });
+    }
+}
+
+impl<'a, T: AbstractOrd<T> + Copy> Extend<&'a T> for SkipList<T> {
+    fn extend<I: IntoIterator<Item = &'a T>>(&mut self, iter: I) {
+        iter.into_iter().for_each(|&elem| {
+            self.insert(elem);
+        });
+    }
+}
+
+impl<T: AbstractOrd<T>> FromIterator<T> for SkipList<T> {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        let mut list = Self::new();
+        list.extend(iter);
+        list
     }
 }
 

--- a/src/skiplist/mod.rs
+++ b/src/skiplist/mod.rs
@@ -164,6 +164,14 @@ impl<T> Drop for SkipList<T> {
     }
 }
 
+impl<T: AbstractOrd<T>> Extend<T> for SkipList<T> {
+    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+        iter.into_iter().for_each(|elem| {
+            self.insert(elem);
+        });
+    }
+}
+
 fn random_height() -> usize {
     const MASK: u32 = 1 << (MAX_HEIGHT - 1);
     1 + (rand::random::<u32>() | MASK).trailing_zeros() as usize


### PR DESCRIPTION
This adds the following:

- `impl<K: Ord, V> Extend<(K, V)> for Map<K, V>`
- `impl<'a, K: Ord + Copy, V: Copy> Extend<(&'a K, &'a V)> for Map<K, V>`
- `impl<K: Ord, V> FromIterator<(K, V)> for Map<K, V>`

- `impl<T: Ord> Extend<T> for Set<T>`
- `impl<'a, T: 'a + Ord + Copy> Extend<&'a T> for Set<T>`
- `impl<T: Ord> FromIterator<T> for Set<T>`

Then with optional `rayon` support, this also adds similar `ParallelExtend` and `FromParallelIterator` implementations.