### PR TITLE
Return found members on insert.

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -12,8 +12,8 @@ impl<K: Ord, V> Map<K, V> {
         Map { inner: SkipList::new() }
     }
 
-    pub fn insert(&self, key: K, value: V) -> Option<(K, V)> {
-        self.inner.insert(KeyValue(key, value)).map(|KeyValue(k, v)| (k, v))
+    pub fn insert(&self, key: K, value: V) -> Option<(K, V, &K, &V)> {
+        self.inner.insert(KeyValue(key, value)).map(|(KeyValue(k, v), kv)| (k, v, &kv.0, &kv.1))
     }
 
     pub fn contains<Q>(&self, key: &Q) -> bool
@@ -30,6 +30,14 @@ impl<K: Ord, V> Map<K, V> {
         K: Borrow<Q>,
     {
         self.inner.get(QWrapper::new(key)).map(|KeyValue(_, v)| v)
+    }
+
+    pub fn get_key_value<Q>(&self, key: &Q) -> Option<(&K, &V)>
+    where
+        Q: Ord + ?Sized,
+        K: Borrow<Q>,
+    {
+        self.inner.get(QWrapper::new(key)).map(|KeyValue(k, v)| (k, v))
     }
 }
 

--- a/src/set.rs
+++ b/src/set.rs
@@ -12,7 +12,7 @@ impl<T: Ord> Set<T> {
         Set { inner: SkipList::new() }
     }
 
-    pub fn insert(&self, elem: T) -> Option<T> {
+    pub fn insert(&self, elem: T) -> Option<(T, &T)> {
         self.inner.insert(elem)
     }
 

--- a/src/skiplist/insert.rs
+++ b/src/skiplist/insert.rs
@@ -8,7 +8,7 @@ use crate::AbstractOrd;
 use super::{Ptr, Node, MAX_HEIGHT};
 
 pub(super) fn insert<'a, T>(lanes: &'a [AtomicPtr<Node<T>>], elem: T, max_height: &AtomicU8)
-    -> Option<T>
+    -> Option<(T, &'a T)>
 where T: AbstractOrd<T>
 {
     // This wonky memory set up is necessary to handle retry iteration: we do
@@ -86,8 +86,8 @@ where T: AbstractOrd<T>
                             // iteration of the 'retry loop). If we have, we
                             // must deallocate that node to avoid leaking it.
                             Equal   => match &mut new_node {
-                                Some(new_node)  => return Some(new_node.as_mut().dealloc()),
-                                None            => return Some(ManuallyDrop::take(&mut elem)),
+                                Some(new_node)  => return Some((new_node.as_mut().dealloc(), &node.inner.elem)),
+                                None            => return Some((ManuallyDrop::take(&mut elem), &node.inner.elem)),
                             }
 
                             // If the element to be inserted is less than the

--- a/src/skiplist/mod.rs
+++ b/src/skiplist/mod.rs
@@ -48,7 +48,7 @@ impl<T: AbstractOrd<T>> SkipList<T> {
         }
     }
 
-    pub fn insert<'a>(&'a self, elem: T) -> Option<T> {
+    pub fn insert<'a>(&'a self, elem: T) -> Option<(T, &'a T)> {
         insert::insert(&self.lanes[..], elem, &self.current_height)
     }
 }


### PR DESCRIPTION
When insert fails, it returns the argument passed into it. With this change, it
also returns a reference to the element the list already contains.

Also add get_key_value to get both the key and the value on map.