### PR TITLE
Change all pointer loads to Acquire.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ assumptions), all of these things should be true:
   skiplist (that is, every lane will always be a subset of the lane below
   it).
 
-Lookup accesses are performed by simply searching through the skiplist using
-Relaxed loads, with no locking or coordination.
+Lookup accesses are performed by simply searching through the skiplist without
+any attempt to acquire locks.
 
 Inserts are performed by finding the location to insert and performing a CAS on
 the pointers in each lane that the node will be inserted to. If the CAS fails

--- a/src/skiplist/get.rs
+++ b/src/skiplist/get.rs
@@ -1,7 +1,7 @@
 use std::cmp::Ordering::*;
 use std::ptr::NonNull;
 use std::sync::atomic::AtomicPtr;
-use std::sync::atomic::Ordering::Relaxed;
+use std::sync::atomic::Ordering::Acquire;
 
 use crate::AbstractOrd;
 use super::{Node, Ptr};
@@ -13,7 +13,7 @@ pub(super) fn get<'a, T, U>(mut lanes: &'a [AtomicPtr<Node<T>>], elem: &U) -> Op
 
     'across: while height > 0 {
         'down: for atomic_ptr in lanes {
-            let ptr: Ptr<Node<T>> = NonNull::new(atomic_ptr.load(Relaxed));
+            let ptr: Ptr<Node<T>> = NonNull::new(atomic_ptr.load(Acquire));
 
             match ptr {
                 None        => {

--- a/src/skiplist/insert.rs
+++ b/src/skiplist/insert.rs
@@ -2,7 +2,7 @@ use std::cmp::Ordering::*;
 use std::mem::ManuallyDrop;
 use std::ptr::{self, NonNull};
 use std::sync::atomic::{AtomicPtr, AtomicU8};
-use std::sync::atomic::Ordering::{Relaxed, AcqRel, Release};
+use std::sync::atomic::Ordering::{Acquire, AcqRel, Release};
 
 use crate::AbstractOrd;
 use super::{Ptr, Node, MAX_HEIGHT};
@@ -60,7 +60,7 @@ where T: AbstractOrd<T>
         // which we are to insert our new node.
         'across: while height > 0 {
             'down: for atomic_ptr in lanes {
-                let ptr: Ptr<Node<T>> = NonNull::new(atomic_ptr.load(Relaxed));
+                let ptr: Ptr<Node<T>> = NonNull::new(atomic_ptr.load(Acquire));
 
                 match ptr {
                     // If the pointer is null, we are at the end of this lane

--- a/src/skiplist/mod.rs
+++ b/src/skiplist/mod.rs
@@ -9,7 +9,7 @@ use std::iter::FromIterator;
 use std::mem;
 use std::ptr::{self, NonNull};
 use std::sync::atomic::{AtomicPtr, AtomicU8};
-use std::sync::atomic::Ordering::Relaxed;
+use std::sync::atomic::Ordering::{Relaxed, Acquire};
 
 use crate::AbstractOrd;
 
@@ -87,7 +87,7 @@ impl<T> SkipList<T> {
     }
 
     fn first(&self) -> Ptr<Node<T>> {
-        NonNull::new(self.lanes[MAX_HEIGHT - 1].load(Relaxed))
+        NonNull::new(self.lanes[MAX_HEIGHT - 1].load(Acquire))
     }
 }
 
@@ -112,7 +112,7 @@ impl<T> Node<T> {
     }
 
     fn next(&self) -> Ptr<Node<T>> {
-        NonNull::new(self.lanes().last().unwrap().load(Relaxed))
+        NonNull::new(self.lanes().last().unwrap().load(Acquire))
     }
 
     fn lanes(&self) -> &[AtomicPtr<Node<T>>] {


### PR DESCRIPTION
To be safe, all pointer loads are changed to Acquire, to be completely certain
that they cannot be dereferenced to a cached value from before the node was
allocated and constructed. Now all operations on AtomicPtr have Acquire and
Release semantics.

The current_height operations are left as Relaxed because they are just a
performance optimization: getting a stale height just makes the look up
slightly slower.

See discussion on Reddit:
https://old.reddit.com/r/rust/comments/c4jgg2/kudzu_concurrent_set_and_map_data_structures/ery3qvx/