### PR TITLE
Implement iterators for Map and Set

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -3,6 +3,7 @@ use std::cmp::Ordering;
 use std::iter::FromIterator;
 
 use crate::{SkipList, AbstractOrd, QWrapper};
+use crate::skiplist::*;
 
 pub struct Map<K, V> {
     inner: SkipList<KeyValue<K, V>>,
@@ -39,6 +40,71 @@ impl<K: Ord, V> Map<K, V> {
         K: Borrow<Q>,
     {
         self.inner.get(QWrapper::new(key)).map(|KeyValue(k, v)| (k, v))
+    }
+
+    pub fn iter(&self) -> Iter<'_, K, V> {
+        IntoIterator::into_iter(self)
+    }
+
+    pub fn iter_mut(&mut self) -> IterMut<'_, K, V> {
+        IntoIterator::into_iter(self)
+    }
+}
+
+impl<K, V> IntoIterator for Map<K, V> {
+    type IntoIter = IntoIter<K, V>;
+    type Item = (K, V);
+    fn into_iter(self) -> Self::IntoIter {
+        IntoIter { inner: self.inner.into_elems() }
+    }
+}
+
+impl<'a, K, V> IntoIterator for &'a Map<K, V> {
+    type IntoIter = Iter<'a, K, V>;
+    type Item = (&'a K, &'a V);
+    fn into_iter(self) -> Self::IntoIter {
+        Iter { inner: self.inner.elems() }
+    }
+}
+
+impl<'a, K, V> IntoIterator for &'a mut Map<K, V> {
+    type IntoIter = IterMut<'a, K, V>;
+    type Item = (&'a K, &'a mut V);
+    fn into_iter(self) -> Self::IntoIter {
+        IterMut { inner: self.inner.elems_mut() }
+    }
+}
+
+pub struct IntoIter<K, V> {
+    inner: IntoElems<KeyValue<K, V>>,
+}
+
+impl<K, V> Iterator for IntoIter<K, V> {
+    type Item = (K, V);
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(|KeyValue(k, v)| (k, v))
+    }
+}
+
+pub struct Iter<'a, K: 'a, V: 'a> {
+    inner: Elems<'a, KeyValue<K, V>>,
+}
+
+impl<'a, K, V> Iterator for Iter<'a, K, V> {
+    type Item = (&'a K, &'a V);
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(|KeyValue(k, v)| (k, v))
+    }
+}
+
+pub struct IterMut<'a, K: 'a, V: 'a> {
+    inner: ElemsMut<'a, KeyValue<K, V>>,
+}
+
+impl<'a, K, V> Iterator for IterMut<'a, K, V> {
+    type Item = (&'a K, &'a mut V);
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(|KeyValue(k, v)| (&*k, v))
     }
 }
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -46,8 +46,20 @@ impl<K: Ord, V> Map<K, V> {
         IntoIterator::into_iter(self)
     }
 
+    pub fn keys(&self) -> Keys<'_, K, V> {
+        Keys { inner: self.iter() }
+    }
+
+    pub fn values(&self) -> Values<'_, K, V> {
+        Values { inner: self.iter() }
+    }
+
     pub fn iter_mut(&mut self) -> IterMut<'_, K, V> {
         IntoIterator::into_iter(self)
+    }
+
+    pub fn values_mut(&mut self) -> ValuesMut<'_, K, V> {
+        ValuesMut { inner: self.iter_mut() }
     }
 }
 
@@ -97,6 +109,28 @@ impl<'a, K, V> Iterator for Iter<'a, K, V> {
     }
 }
 
+pub struct Keys<'a, K: 'a, V: 'a> {
+    inner: Iter<'a, K, V>,
+}
+
+impl<'a, K, V> Iterator for Keys<'a, K, V> {
+    type Item = &'a K;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(|(k, _)| k)
+    }
+}
+
+pub struct Values<'a, K: 'a, V: 'a> {
+    inner: Iter<'a, K, V>,
+}
+
+impl<'a, K, V> Iterator for Values<'a, K, V> {
+    type Item = &'a V;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(|(_, v)| v)
+    }
+}
+
 pub struct IterMut<'a, K: 'a, V: 'a> {
     inner: ElemsMut<'a, KeyValue<K, V>>,
 }
@@ -105,6 +139,17 @@ impl<'a, K, V> Iterator for IterMut<'a, K, V> {
     type Item = (&'a K, &'a mut V);
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next().map(|KeyValue(k, v)| (&*k, v))
+    }
+}
+
+pub struct ValuesMut<'a, K: 'a, V: 'a> {
+    inner: IterMut<'a, K, V>,
+}
+
+impl<'a, K, V> Iterator for ValuesMut<'a, K, V> {
+    type Item = &'a mut V;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(|(_, v)| v)
     }
 }
 

--- a/src/set.rs
+++ b/src/set.rs
@@ -1,4 +1,5 @@
 use std::borrow::Borrow;
+use std::cmp::Ordering;
 use std::iter::FromIterator;
 
 use crate::{SkipList, QWrapper};
@@ -35,6 +36,34 @@ impl<T: Ord> Set<T> {
 
     pub fn iter(&self) -> Iter<'_, T> {
         IntoIterator::into_iter(self)
+    }
+
+    pub fn difference<'a>(&'a self, other: &'a Self) -> Difference<'a, T> {
+        Difference {
+            left: self.inner.elems(),
+            right: other.inner.elems(),
+        }
+    }
+
+    pub fn symmetric_difference<'a>(&'a self, other: &'a Self) -> SymmetricDifference<'a, T> {
+        SymmetricDifference {
+            left: self.inner.elems(),
+            right: other.inner.elems(),
+        }
+    }
+
+    pub fn intersection<'a>(&'a self, other: &'a Self) -> Intersection<'a, T> {
+        Intersection {
+            left: self.inner.elems(),
+            right: other.inner.elems(),
+        }
+    }
+
+    pub fn union<'a>(&'a self, other: &'a Self) -> Union<'a, T> {
+        Union {
+            left: self.inner.elems(),
+            right: other.inner.elems(),
+        }
     }
 }
 
@@ -76,6 +105,129 @@ impl<'a, T: 'a> Iterator for Iter<'a, T> {
     }
 }
 
+pub struct Difference<'a, T> {
+    left: Elems<'a, T>,
+    right: Elems<'a, T>,
+}
+
+impl<'a, T: Ord> Iterator for Difference<'a, T> {
+    type Item = &'a T;
+    fn next(&mut self) -> Option<Self::Item> {
+        // Find the next left that's less than the next right
+        'left: loop {
+            // When the left is empty, we're done
+            let left = self.left.next()?;
+            // Peek the next right and compare
+            while let Some(right) = self.right.peek() {
+                match left.cmp(right) {
+                    Ordering::Less => break,
+                    Ordering::Equal => {
+                        // Consume right and get a new left
+                        self.right.next();
+                        continue 'left;
+                    }
+                    Ordering::Greater => {
+                        // Consume right, so we'll peek a new one
+                        self.right.next();
+                    }
+                }
+            }
+            // Found Less, or right was None
+            return Some(left);
+        }
+    }
+}
+
+pub struct SymmetricDifference<'a, T> {
+    left: Elems<'a, T>,
+    right: Elems<'a, T>,
+}
+
+impl<'a, T: Ord> Iterator for SymmetricDifference<'a, T> {
+    type Item = &'a T;
+    fn next(&mut self) -> Option<Self::Item> {
+        // Find the next exclusive value from the left or right
+        loop {
+            return match (self.left.peek(), self.right.peek()) {
+                // Both are empty
+                (None, None) => None,
+                // The right is empty -- consume the left
+                (Some(_), None) => self.left.next(),
+                // The left is empty -- consume the right
+                (None, Some(_)) => self.right.next(),
+                // Both have values -- return the lesser
+                (Some(left), Some(right)) => match left.cmp(right) {
+                    Ordering::Less => self.left.next(),
+                    Ordering::Greater => self.right.next(),
+                    Ordering::Equal => {
+                        // Discard equal values and try again
+                        self.left.next();
+                        self.right.next();
+                        continue;
+                    }
+                },
+            };
+        }
+    }
+}
+
+pub struct Intersection<'a, T> {
+    left: Elems<'a, T>,
+    right: Elems<'a, T>,
+}
+
+impl<'a, T: Ord> Iterator for Intersection<'a, T> {
+    type Item = &'a T;
+    fn next(&mut self) -> Option<Self::Item> {
+        // Find the next value that exists in both
+        loop {
+            // When either is empty, we're done
+            let left = self.left.peek()?;
+            let right = self.right.peek()?;
+            match left.cmp(right) {
+                // Discard the lesser inequal value
+                Ordering::Less => self.left.next(),
+                Ordering::Greater => self.right.next(),
+                Ordering::Equal => {
+                    // Consume both, returning the left
+                    self.right.next();
+                    return self.left.next();
+                }
+            };
+        }
+    }
+}
+
+pub struct Union<'a, T> {
+    left: Elems<'a, T>,
+    right: Elems<'a, T>,
+}
+
+impl<'a, T: Ord> Iterator for Union<'a, T> {
+    type Item = &'a T;
+    fn next(&mut self) -> Option<Self::Item> {
+        // Find the next value from either
+        match (self.left.peek(), self.right.peek()) {
+            // Both are empty
+            (None, None) => None,
+            // The right is empty -- consume the left
+            (Some(_), None) => self.left.next(),
+            // The left is empty -- consume the right
+            (None, Some(_)) => self.right.next(),
+            (Some(left), Some(right)) => match left.cmp(right) {
+                // Return the lesser inequal value
+                Ordering::Less => self.left.next(),
+                Ordering::Greater => self.right.next(),
+                Ordering::Equal => {
+                    // Consume both, returning the left
+                    self.right.next();
+                    self.left.next()
+                }
+            },
+        }
+    }
+}
+
 impl<T: Ord> Extend<T> for Set<T> {
     fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
         self.inner.extend(iter);
@@ -101,4 +253,74 @@ fn test_collect() {
     let range = 0..100;
     let set: Set<_> = range.clone().collect();
     range.for_each(|i| assert!(set.contains(&i)));
+}
+
+#[cfg(test)]
+mod test_iterators {
+    use super::Set;
+    use std::collections::BTreeSet;
+
+    static SINGLES: &[u32] = &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+    static EVENS: &[u32] = &[0, 2, 4, 6, 8, 10, 12, 14, 16, 18];
+    static ODDS: &[u32] = &[1, 3, 5, 7, 9, 11, 13, 15, 17, 19];
+    static PRIMES: &[u32] = &[2, 3, 5, 7, 11, 13, 17, 19, 23, 29];
+    static SETS: &[&[u32]] = &[SINGLES, EVENS, ODDS, PRIMES];
+
+    fn collect<'a, I, C>(iter: I) -> C
+    where
+        I: IntoIterator<Item = &'a u32>,
+        C: std::iter::FromIterator<u32>,
+    {
+        iter.into_iter().copied().collect()
+    }
+
+    fn compare<F, G>(f: F, g: G)
+    where
+        F: Fn(&Set<u32>, &Set<u32>) -> Vec<u32>,
+        G: Fn(&BTreeSet<u32>, &BTreeSet<u32>) -> Vec<u32>,
+    {
+        for &left in SETS {
+            let a1: Set<_> = collect(left);
+            let b1: BTreeSet<_> = collect(left);
+
+            for &right in SETS {
+                let a2: Set<_> = collect(right);
+                let b2: BTreeSet<_> = collect(right);
+
+                assert_eq!(f(&a1, &a2), g(&b1, &b2));
+            }
+        }
+    }
+
+    #[test]
+    fn difference() {
+        compare(
+            |a, b| collect(a.difference(b)),
+            |a, b| collect(a.difference(b)),
+        );
+    }
+
+    #[test]
+    fn symmetric_difference() {
+        compare(
+            |a, b| collect(a.symmetric_difference(b)),
+            |a, b| collect(a.symmetric_difference(b)),
+        );
+    }
+
+    #[test]
+    fn intersection() {
+        compare(
+            |a, b| collect(a.intersection(b)),
+            |a, b| collect(a.intersection(b)),
+        );
+    }
+
+    #[test]
+    fn union() {
+        compare(
+            |a, b| collect(a.union(b)),
+            |a, b| collect(a.union(b))
+        );
+    }
 }

--- a/src/skiplist/iter.rs
+++ b/src/skiplist/iter.rs
@@ -15,6 +15,12 @@ impl<'a, T> Nodes<'a, T> {
     }
 }
 
+impl<'a, T> Nodes<'a, T> {
+    fn peek(&self) -> Option<&Node<T>> {
+        unsafe { mem::transmute(self.ptr) }
+    }
+}
+
 impl<'a, T> Iterator for Nodes<'a, T> {
     type Item = &'a Node<T>;
     fn next(&mut self) -> Option<&'a Node<T>> {
@@ -56,6 +62,12 @@ impl<'a, T> Iterator for NodesMut<'a, T> {
 
 pub struct Elems<'a, T> {
     pub(super) nodes: Nodes<'a, T>
+}
+
+impl<'a, T> Elems<'a, T> {
+    pub(crate) fn peek(&self) -> Option<&T> {
+        self.nodes.peek().map(|node| &node.inner.elem)
+    }
 }
 
 impl<'a, T> Iterator for Elems<'a, T> {


### PR DESCRIPTION
This adds:

- `Map::{iter, iter_mut, into_iter}`
- `Map::{keys, values, values_mut}`
- `Set::{difference, symmetric_difference, intersection, union}`

We already have `Set::{iter, into_iter}`, and sets don't usually have `iter_mut`.

Fixes #1.